### PR TITLE
free nade bug

### DIFF
--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -2528,6 +2528,7 @@ static void PM_Weapon( void ) {
 					pm->ps->grenadeTimeLeft = 100;
 					PM_AddEvent( EV_FIRE_WEAPON );
 					pm->ps->weaponTime = 1600;
+					PM_WeaponUseAmmo( pm->ps->weapon, ammoTable[pm->ps->weapon].uses );
 					return;
 				}
 			}

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -1426,6 +1426,8 @@ qboolean    BG_PlayerSeesItem( playerState_t *ps, entityState_t *item, int atTim
 
 //----(SA)	removed PM_ammoNeeded 11/27/00
 void PM_ClipVelocity( vec3_t in, vec3_t normal, vec3_t out, float overbounce );
+// needed to call from player_die()
+void PM_WeaponUseAmmo( int wp, int amount );
 
 #define ARENAS_PER_TIER     4
 #define MAX_ARENAS          64

--- a/src/game/g_combat.c
+++ b/src/game/g_combat.c
@@ -360,6 +360,7 @@ void player_die( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int
 		VectorCopy( self->r.currentOrigin, launchspot );
 		launchspot[2] += 40;
 		fire_grenade( self, launchspot, launchvel, self->s.weapon );
+		PM_WeaponUseAmmo( self->s.weapon, ammoTable[self->s.weapon].uses );
 
 	}
 


### PR DESCRIPTION
fix free nade bug when nade explodes while still holding attack button or dying while holding nade.

issues https://github.com/rtcwmp-com/WolfPro/issues/19 and https://github.com/rtcwmp-com/WolfPro/issues/4